### PR TITLE
[WIP] Implements padding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,9 @@ libm = "0.2"
 ring = "0.16"
 lazy_static = "1"
 qlog = { version = "0.3", path = "tools/qlog", optional = true }
+ordered-float = "2.0"
+rand = "0.7"
+rand_distr = "0.3.0"
 
 [target."cfg(windows)".dependencies]
 winapi = { version = "0.3", features = ["wincrypt"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -913,7 +913,7 @@ pub struct Connection {
     qlogged_peer_params: bool,
 
     /// The padding algorithm used. See `padding.rs`
-    padding_algorithm: Box<dyn Padding + Send>,
+    padding_algorithm: Box<dyn Padding + Send>, //TODO: it seems weird to that the whole object is Send. It is certainly not thread-safe yet
 }
 
 /// Creates a new server-side connection.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,24 +319,24 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[repr(C)]
 pub enum Error {
     /// There is no more work to do.
-    Done               = -1,
+    Done = -1,
 
     /// The provided buffer is too short.
-    BufferTooShort     = -2,
+    BufferTooShort = -2,
 
     /// The provided packet cannot be parsed because its version is unknown.
-    UnknownVersion     = -3,
+    UnknownVersion = -3,
 
     /// The provided packet cannot be parsed because it contains an invalid
     /// frame.
-    InvalidFrame       = -4,
+    InvalidFrame = -4,
 
     /// The provided packet cannot be parsed.
-    InvalidPacket      = -5,
+    InvalidPacket = -5,
 
     /// The operation cannot be completed because the connection is in an
     /// invalid state.
-    InvalidState       = -6,
+    InvalidState = -6,
 
     /// The operation cannot be completed because the stream is in an
     /// invalid state.
@@ -346,22 +346,22 @@ pub enum Error {
     InvalidTransportParam = -8,
 
     /// A cryptographic operation failed.
-    CryptoFail         = -9,
+    CryptoFail = -9,
 
     /// The TLS handshake failed.
-    TlsFail            = -10,
+    TlsFail = -10,
 
     /// The peer violated the local flow control limits.
-    FlowControl        = -11,
+    FlowControl = -11,
 
     /// The peer violated the local stream limits.
-    StreamLimit        = -12,
+    StreamLimit = -12,
 
     /// The received data exceeds the stream's final size.
-    FinalSize          = -13,
+    FinalSize = -13,
 
     /// Error in congestion control.
-    CongestionControl  = -14,
+    CongestionControl = -14,
 }
 
 impl Error {
@@ -409,7 +409,7 @@ impl std::convert::From<octets::BufferTooShortError> for Error {
 #[repr(C)]
 pub enum Shutdown {
     /// Stop receiving stream data.
-    Read  = 0,
+    Read = 0,
 
     /// Stop sending stream data.
     Write = 1,
@@ -428,6 +428,8 @@ pub struct Config {
     grease: bool,
 
     cc_algorithm: CongestionControlAlgorithm,
+
+    padding_algorithm: PaddingAlgorithm,
 
     hystart: bool,
 }
@@ -451,6 +453,7 @@ impl Config {
             application_protos: Vec::new(),
             grease: true,
             cc_algorithm: CongestionControlAlgorithm::CUBIC,
+            padding_algorithm: PaddingAlgorithm::None,
             hystart: true,
         })
     }
@@ -730,6 +733,30 @@ impl Config {
     /// The default value is `CongestionControlAlgorithm::CUBIC`.
     pub fn set_cc_algorithm(&mut self, algo: CongestionControlAlgorithm) {
         self.cc_algorithm = algo;
+    }
+
+    /// Sets the padding algorithm used by string.
+    ///
+    /// The default value is `none`.
+    ///
+    /// ## Examples:
+    ///
+    /// ```
+    /// # let mut config = quiche::Config::new(0xbabababa)?;
+    /// config.set_padding_algorithm_name("wtfpad");
+    /// # Ok::<(), quiche::Error>(())
+    /// ```
+    pub fn set_padding_algorithm_name(&mut self, name: &str) -> Result<()> {
+        self.padding_algorithm = PaddingAlgorithm::from_str(name)?;
+
+        Ok(())
+    }
+
+    /// Sets the padding algorithm used.
+    ///
+    /// The default value is `PaddingAlgorithm::None`.
+    pub fn set_padding_algorithm(&mut self, algo: PaddingAlgorithm) {
+        self.padding_algorithm = algo;
     }
 
     /// Configures whether to enable HyStart++.
@@ -1038,9 +1065,9 @@ pub fn retry(
 /// Returns true if the given protocol version is supported.
 pub fn version_is_supported(version: u32) -> bool {
     match version {
-        PROTOCOL_VERSION_DRAFT27 |
-        PROTOCOL_VERSION_DRAFT28 |
-        PROTOCOL_VERSION_DRAFT29 => true,
+        PROTOCOL_VERSION_DRAFT27
+        | PROTOCOL_VERSION_DRAFT28
+        | PROTOCOL_VERSION_DRAFT29 => true,
 
         _ => false,
     }
@@ -1369,7 +1396,7 @@ impl Connection {
                     // the connection.
                     self.close(false, e.to_wire(), b"").ok();
                     return Err(e);
-                },
+                }
             };
 
             done += read;
@@ -1464,7 +1491,7 @@ impl Connection {
                     // this error is quite useful for debugging, so don't just
                     // ignore the packet.
                     return Err(Error::UnknownVersion);
-                },
+                }
             };
 
             self.did_version_negotiation = true;
@@ -1598,8 +1625,8 @@ impl Connection {
         let epoch = hdr.ty.to_epoch()?;
 
         // TODO: somehow deal with re-ordered 0-RTT data.
-        let aead = if hdr.ty == packet::Type::ZeroRTT &&
-            self.pkt_num_spaces[epoch].crypto_0rtt_open.is_some()
+        let aead = if hdr.ty == packet::Type::ZeroRTT
+            && self.pkt_num_spaces[epoch].crypto_0rtt_open.is_some()
         {
             // TODO: buffer 0-RTT packets instead of discarding when key is not
             // available yet, as an optimization.
@@ -1621,13 +1648,14 @@ impl Connection {
                 //
                 // TODO: buffer 1-RTT packets instead of discarding when key is
                 // not available yet, as an optimization.
-                None =>
+                None => {
                     return Err(drop_pkt_on_err(
                         Error::CryptoFail,
                         self.recv_count,
                         self.is_server,
                         &self.trace_id,
-                    )),
+                    ))
+                }
             }
         };
 
@@ -1788,14 +1816,14 @@ impl Connection {
                             .recv_pkt_need_ack
                             .remove_until(largest_acked);
                     }
-                },
+                }
 
                 frame::Frame::Crypto { data } => {
                     self.pkt_num_spaces[epoch]
                         .crypto_stream
                         .send
                         .ack(data.off(), data.len());
-                },
+                }
 
                 frame::Frame::Stream { stream_id, data } => {
                     let stream = match self.streams.get_mut(stream_id) {
@@ -1810,7 +1838,7 @@ impl Connection {
                         let local = stream.local;
                         self.streams.collect(stream_id, local);
                     }
-                },
+                }
 
                 _ => (),
             }
@@ -1939,7 +1967,7 @@ impl Connection {
             match lost {
                 frame::Frame::Crypto { data } => {
                     self.pkt_num_spaces[epoch].crypto_stream.send.push(data)?;
-                },
+                }
 
                 frame::Frame::Stream { stream_id, data } => {
                     let stream = match self.streams.get_mut(stream_id) {
@@ -1968,25 +1996,25 @@ impl Connection {
                             incremental,
                         );
                     }
-                },
+                }
 
                 frame::Frame::ACK { .. } => {
                     self.pkt_num_spaces[epoch].ack_elicited = true;
-                },
+                }
 
                 frame::Frame::HandshakeDone => {
                     self.handshake_done_sent = false;
-                },
+                }
 
                 frame::Frame::MaxStreamData { stream_id, .. } => {
                     if self.streams.get(stream_id).is_some() {
                         self.streams.mark_almost_full(stream_id, true);
                     }
-                },
+                }
 
                 frame::Frame::MaxData { .. } => {
                     self.almost_full = true;
-                },
+                }
 
                 _ => (),
             }
@@ -2082,7 +2110,7 @@ impl Connection {
                 // is set to false here to make cwnd grow when ACK is received.
                 self.recovery.update_app_limited(false);
                 return Err(Error::Done);
-            },
+            }
         }
 
         let mut frames: Vec<frame::Frame> = Vec::new();
@@ -2094,16 +2122,16 @@ impl Connection {
         let mut payload_len = 0;
 
         // Create ACK frame.
-        if self.pkt_num_spaces[epoch].recv_pkt_need_ack.len() > 0 &&
-            (self.pkt_num_spaces[epoch].ack_elicited ||
-                self.recovery.loss_probes[epoch] > 0) &&
-            !is_closing
+        if self.pkt_num_spaces[epoch].recv_pkt_need_ack.len() > 0
+            && (self.pkt_num_spaces[epoch].ack_elicited
+                || self.recovery.loss_probes[epoch] > 0)
+            && !is_closing
         {
             let ack_delay =
                 self.pkt_num_spaces[epoch].largest_rx_pkt_time.elapsed();
 
-            let ack_delay = ack_delay.as_micros() as u64 /
-                2_u64
+            let ack_delay = ack_delay.as_micros() as u64
+                / 2_u64
                     .pow(self.local_transport_params.ack_delay_exponent as u32);
 
             let frame = frame::Frame::ACK {
@@ -2118,9 +2146,9 @@ impl Connection {
 
         if pkt_type == packet::Type::Short && !is_closing {
             // Create HANDSHAKE_DONE frame.
-            if self.is_established() &&
-                !self.handshake_done_sent &&
-                self.is_server
+            if self.is_established()
+                && !self.handshake_done_sent
+                && self.is_server
             {
                 let frame = frame::Frame::HandshakeDone;
 
@@ -2199,7 +2227,7 @@ impl Connection {
                         // the almost full set.
                         self.streams.mark_almost_full(stream_id, false);
                         continue;
-                    },
+                    }
                 };
 
                 let frame = frame::Frame::MaxStreamData {
@@ -2283,9 +2311,9 @@ impl Connection {
         }
 
         // Create CRYPTO frame.
-        if self.pkt_num_spaces[epoch].crypto_stream.is_flushable() &&
-            left > frame::MAX_CRYPTO_OVERHEAD &&
-            !is_closing
+        if self.pkt_num_spaces[epoch].crypto_stream.is_flushable()
+            && left > frame::MAX_CRYPTO_OVERHEAD
+            && !is_closing
         {
             let crypto_len = left - frame::MAX_CRYPTO_OVERHEAD;
             let crypto_buf = self.pkt_num_spaces[epoch]
@@ -2303,9 +2331,9 @@ impl Connection {
         }
 
         // Create a single STREAM frame for the first stream that is flushable.
-        if pkt_type == packet::Type::Short &&
-            left > frame::MAX_STREAM_OVERHEAD &&
-            !is_closing
+        if pkt_type == packet::Type::Short
+            && left > frame::MAX_STREAM_OVERHEAD
+            && !is_closing
         {
             while let Some(stream_id) = self.streams.pop_flushable() {
                 let stream = match self.streams.get_mut(stream_id) {
@@ -2319,10 +2347,10 @@ impl Connection {
                 // Try to accurately account for the STREAM frame's overhead,
                 // such that we can fill as much of the packet buffer as
                 // possible.
-                let overhead = 1 +
-                    octets::varint_len(stream_id) +
-                    octets::varint_len(off) +
-                    octets::varint_len(left as u64);
+                let overhead = 1
+                    + octets::varint_len(stream_id)
+                    + octets::varint_len(off)
+                    + octets::varint_len(left as u64);
 
                 let max_len = match left.checked_sub(overhead) {
                     Some(v) => v,
@@ -2367,10 +2395,10 @@ impl Connection {
         }
 
         // Create PING for PTO probe if no other ack-elicitng frame is sent.
-        if self.recovery.loss_probes[epoch] > 0 &&
-            !ack_eliciting &&
-            left >= 1 &&
-            !is_closing
+        if self.recovery.loss_probes[epoch] > 0
+            && !ack_eliciting
+            && left >= 1
+            && !is_closing
         {
             let frame = frame::Frame::Ping;
 
@@ -2572,8 +2600,8 @@ impl Connection {
         &mut self, stream_id: u64, out: &mut [u8],
     ) -> Result<(usize, bool)> {
         // We can't read on our own unidirectional streams.
-        if !stream::is_bidi(stream_id) &&
-            stream::is_local(stream_id, self.is_server)
+        if !stream::is_bidi(stream_id)
+            && stream::is_local(stream_id, self.is_server)
         {
             return Err(Error::InvalidStreamState);
         }
@@ -2670,8 +2698,8 @@ impl Connection {
         &mut self, stream_id: u64, buf: &[u8], fin: bool,
     ) -> Result<usize> {
         // We can't write on the peer's unidirectional streams.
-        if !stream::is_bidi(stream_id) &&
-            !stream::is_local(stream_id, self.is_server)
+        if !stream::is_bidi(stream_id)
+            && !stream::is_local(stream_id, self.is_server)
         {
             return Err(Error::InvalidStreamState);
         }
@@ -2817,7 +2845,7 @@ impl Connection {
 
                 // Once shutdown, the stream is guaranteed to be non-readable.
                 self.streams.mark_readable(stream_id, false);
-            },
+            }
 
             // TODO: send RESET_STREAM
             Shutdown::Write => {
@@ -2825,7 +2853,7 @@ impl Connection {
 
                 // Once shutdown, the stream is guaranteed to be non-writable.
                 self.streams.mark_writable(stream_id, false);
-            },
+            }
         }
 
         Ok(())
@@ -3258,14 +3286,14 @@ impl Connection {
 
         // If there are flushable, almost full or blocked streams, use the
         // Application epoch.
-        if (self.is_established() || self.is_in_early_data()) &&
-            (self.almost_full ||
-                self.blocked_limit.is_some() ||
-                self.streams.should_update_max_streams_bidi() ||
-                self.streams.should_update_max_streams_uni() ||
-                self.streams.has_flushable() ||
-                self.streams.has_almost_full() ||
-                self.streams.has_blocked())
+        if (self.is_established() || self.is_in_early_data())
+            && (self.almost_full
+                || self.blocked_limit.is_some()
+                || self.streams.should_update_max_streams_bidi()
+                || self.streams.should_update_max_streams_uni()
+                || self.streams.has_flushable()
+                || self.streams.has_almost_full()
+                || self.streams.has_blocked())
         {
             return Ok(packet::EPOCH_APPLICATION);
         }
@@ -3330,7 +3358,7 @@ impl Connection {
                 if self.handshake_confirmed {
                     self.drop_epoch_state(packet::EPOCH_HANDSHAKE, now);
                 }
-            },
+            }
 
             frame::Frame::ResetStream {
                 stream_id,
@@ -3338,8 +3366,8 @@ impl Connection {
                 ..
             } => {
                 // Peer can't send on our unidirectional streams.
-                if !stream::is_bidi(stream_id) &&
-                    stream::is_local(stream_id, self.is_server)
+                if !stream::is_bidi(stream_id)
+                    && stream::is_local(stream_id, self.is_server)
                 {
                     return Err(Error::InvalidStreamState);
                 }
@@ -3367,16 +3395,16 @@ impl Connection {
                 if self.rx_data > self.max_rx_data {
                     return Err(Error::FlowControl);
                 }
-            },
+            }
 
             frame::Frame::StopSending { stream_id, .. } => {
                 // STOP_SENDING on a receive-only stream is a fatal error.
-                if !stream::is_local(stream_id, self.is_server) &&
-                    !stream::is_bidi(stream_id)
+                if !stream::is_local(stream_id, self.is_server)
+                    && !stream::is_bidi(stream_id)
                 {
                     return Err(Error::InvalidStreamState);
                 }
-            },
+            }
 
             frame::Frame::Crypto { data } => {
                 // Push the data to the stream so it can be re-ordered.
@@ -3412,8 +3440,9 @@ impl Connection {
                     if self.version >= PROTOCOL_VERSION_DRAFT28 {
                         // Validate initial_source_connection_id.
                         match &peer_params.initial_source_connection_id {
-                            Some(v) if v != &self.dcid =>
-                                return Err(Error::InvalidTransportParam),
+                            Some(v) if v != &self.dcid => {
+                                return Err(Error::InvalidTransportParam)
+                            }
 
                             Some(_) => (),
 
@@ -3426,15 +3455,17 @@ impl Connection {
                         if let Some(odcid) = &self.odcid {
                             match &peer_params.original_destination_connection_id
                             {
-                                Some(v) if v != odcid =>
-                                    return Err(Error::InvalidTransportParam),
+                                Some(v) if v != odcid => {
+                                    return Err(Error::InvalidTransportParam)
+                                }
 
                                 Some(_) => (),
 
                                 // original_destination_connection_id must be
                                 // sent by the server.
-                                None if !self.is_server =>
-                                    return Err(Error::InvalidTransportParam),
+                                None if !self.is_server => {
+                                    return Err(Error::InvalidTransportParam)
+                                }
 
                                 None => (),
                             }
@@ -3443,8 +3474,9 @@ impl Connection {
                         // Validate retry_source_connection_id.
                         if let Some(rscid) = &self.rscid {
                             match &peer_params.retry_source_connection_id {
-                                Some(v) if v != rscid =>
-                                    return Err(Error::InvalidTransportParam),
+                                Some(v) if v != rscid => {
+                                    return Err(Error::InvalidTransportParam)
+                                }
 
                                 Some(_) => (),
 
@@ -3456,9 +3488,9 @@ impl Connection {
                     } else {
                         // Legacy validation of the original connection ID when
                         // stateless retry is performed, for drafts < 28.
-                        if self.did_retry &&
-                            peer_params.original_destination_connection_id !=
-                                self.odcid
+                        if self.did_retry
+                            && peer_params.original_destination_connection_id
+                                != self.odcid
                         {
                             return Err(Error::InvalidTransportParam);
                         }
@@ -3481,15 +3513,15 @@ impl Connection {
 
                     self.parsed_peer_transport_params = true;
                 }
-            },
+            }
 
             // TODO: implement stateless retry
             frame::Frame::NewToken { .. } => (),
 
             frame::Frame::Stream { stream_id, data } => {
                 // Peer can't send on our unidirectional streams.
-                if !stream::is_bidi(stream_id) &&
-                    stream::is_local(stream_id, self.is_server)
+                if !stream::is_bidi(stream_id)
+                    && stream::is_local(stream_id, self.is_server)
                 {
                     return Err(Error::InvalidStreamState);
                 }
@@ -3526,11 +3558,11 @@ impl Connection {
                 }
 
                 self.rx_data += data_len;
-            },
+            }
 
             frame::Frame::MaxData { max } => {
                 self.max_tx_data = cmp::max(self.max_tx_data, max);
-            },
+            }
 
             frame::Frame::MaxStreamData { stream_id, max } => {
                 // Get existing stream or create a new one, but if the stream
@@ -3568,7 +3600,7 @@ impl Connection {
                 if writable {
                     self.streams.mark_writable(stream_id, true);
                 }
-            },
+            }
 
             frame::Frame::MaxStreamsBidi { max } => {
                 if max > MAX_STREAM_ID {
@@ -3576,7 +3608,7 @@ impl Connection {
                 }
 
                 self.streams.update_peer_max_streams_bidi(max);
-            },
+            }
 
             frame::Frame::MaxStreamsUni { max } => {
                 if max > MAX_STREAM_ID {
@@ -3584,21 +3616,23 @@ impl Connection {
                 }
 
                 self.streams.update_peer_max_streams_uni(max);
-            },
+            }
 
             frame::Frame::DataBlocked { .. } => (),
 
             frame::Frame::StreamDataBlocked { .. } => (),
 
-            frame::Frame::StreamsBlockedBidi { limit } =>
+            frame::Frame::StreamsBlockedBidi { limit } => {
                 if limit > MAX_STREAM_ID {
                     return Err(Error::InvalidFrame);
-                },
+                }
+            }
 
-            frame::Frame::StreamsBlockedUni { limit } =>
+            frame::Frame::StreamsBlockedUni { limit } => {
                 if limit > MAX_STREAM_ID {
                     return Err(Error::InvalidFrame);
-                },
+                }
+            }
 
             // TODO: implement connection migration
             frame::Frame::NewConnectionId { .. } => (),
@@ -3608,17 +3642,17 @@ impl Connection {
 
             frame::Frame::PathChallenge { data } => {
                 self.challenge = Some(data);
-            },
+            }
 
             frame::Frame::PathResponse { .. } => (),
 
             frame::Frame::ConnectionClose { .. } => {
                 self.draining_timer = Some(now + (self.recovery.pto() * 3));
-            },
+            }
 
             frame::Frame::ApplicationClose { .. } => {
                 self.draining_timer = Some(now + (self.recovery.pto() * 3));
-            },
+            }
 
             frame::Frame::HandshakeDone => {
                 if self.is_server {
@@ -3631,7 +3665,7 @@ impl Connection {
 
                 // Once the handshake is confirmed, we can drop Handshake keys.
                 self.drop_epoch_state(packet::EPOCH_HANDSHAKE, now);
-            },
+            }
         }
 
         Ok(())
@@ -3661,8 +3695,8 @@ impl Connection {
     /// This happens when the new max data limit is at least double the amount
     /// of data that can be received before blocking.
     fn should_update_max_data(&self) -> bool {
-        self.max_rx_data_next != self.max_rx_data &&
-            self.max_rx_data_next / 2 > self.max_rx_data - self.rx_data
+        self.max_rx_data_next != self.max_rx_data
+            && self.max_rx_data_next / 2 > self.max_rx_data - self.rx_data
     }
 
     /// Returns the idle timeout value.
@@ -3672,8 +3706,8 @@ impl Connection {
         // If the transport parameter is set to 0, then the respective endpoint
         // decided to disable the idle timeout. If both are disabled we should
         // not set any timeout.
-        if self.local_transport_params.max_idle_timeout == 0 &&
-            self.peer_transport_params.max_idle_timeout == 0
+        if self.local_transport_params.max_idle_timeout == 0
+            && self.peer_transport_params.max_idle_timeout == 0
         {
             return None;
         }
@@ -3856,11 +3890,11 @@ impl TransportParams {
                     }
 
                     tp.original_destination_connection_id = Some(val.to_vec());
-                },
+                }
 
                 0x0001 => {
                     tp.max_idle_timeout = val.get_varint()?;
-                },
+                }
 
                 0x0002 => {
                     if is_server {
@@ -3868,7 +3902,7 @@ impl TransportParams {
                     }
 
                     tp.stateless_reset_token = Some(val.get_bytes(16)?.to_vec());
-                },
+                }
 
                 0x0003 => {
                     tp.max_udp_payload_size = val.get_varint()?;
@@ -3876,23 +3910,23 @@ impl TransportParams {
                     if tp.max_udp_payload_size < 1200 {
                         return Err(Error::InvalidTransportParam);
                     }
-                },
+                }
 
                 0x0004 => {
                     tp.initial_max_data = val.get_varint()?;
-                },
+                }
 
                 0x0005 => {
                     tp.initial_max_stream_data_bidi_local = val.get_varint()?;
-                },
+                }
 
                 0x0006 => {
                     tp.initial_max_stream_data_bidi_remote = val.get_varint()?;
-                },
+                }
 
                 0x0007 => {
                     tp.initial_max_stream_data_uni = val.get_varint()?;
-                },
+                }
 
                 0x0008 => {
                     let max = val.get_varint()?;
@@ -3902,7 +3936,7 @@ impl TransportParams {
                     }
 
                     tp.initial_max_streams_bidi = max;
-                },
+                }
 
                 0x0009 => {
                     let max = val.get_varint()?;
@@ -3912,7 +3946,7 @@ impl TransportParams {
                     }
 
                     tp.initial_max_streams_uni = max;
-                },
+                }
 
                 0x000a => {
                     let ack_delay_exponent = val.get_varint()?;
@@ -3922,7 +3956,7 @@ impl TransportParams {
                     }
 
                     tp.ack_delay_exponent = ack_delay_exponent;
-                },
+                }
 
                 0x000b => {
                     let max_ack_delay = val.get_varint()?;
@@ -3932,11 +3966,11 @@ impl TransportParams {
                     }
 
                     tp.max_ack_delay = max_ack_delay;
-                },
+                }
 
                 0x000c => {
                     tp.disable_active_migration = true;
-                },
+                }
 
                 0x000d => {
                     if is_server {
@@ -3944,7 +3978,7 @@ impl TransportParams {
                     }
 
                     // TODO: decode preferred_address
-                },
+                }
 
                 0x000e => {
                     let limit = val.get_varint()?;
@@ -3954,11 +3988,11 @@ impl TransportParams {
                     }
 
                     tp.active_conn_id_limit = limit;
-                },
+                }
 
                 0x000f => {
                     tp.initial_source_connection_id = Some(val.to_vec());
-                },
+                }
 
                 0x00010 => {
                     if is_server {
@@ -3966,7 +4000,7 @@ impl TransportParams {
                     }
 
                     tp.retry_source_connection_id = Some(val.to_vec());
-                },
+                }
 
                 // Ignore unknown parameters.
                 _ => (),
@@ -4390,8 +4424,8 @@ pub mod testing {
 
         hdr.to_bytes(&mut b)?;
 
-        let payload_len = frames.iter().fold(0, |acc, x| acc + x.wire_len()) +
-            space.crypto_overhead().unwrap();
+        let payload_len = frames.iter().fold(0, |acc, x| acc + x.wire_len())
+            + space.crypto_overhead().unwrap();
 
         if pkt_type != packet::Type::Short {
             let len = pn_len + payload_len;
@@ -5819,8 +5853,8 @@ mod tests {
         let space = &mut pipe.client.pkt_num_spaces[epoch];
 
         // Use correct payload length when encrypting the packet.
-        let payload_len = frames.iter().fold(0, |acc, x| acc + x.wire_len()) +
-            space.crypto_overhead().unwrap();
+        let payload_len = frames.iter().fold(0, |acc, x| acc + x.wire_len())
+            + space.crypto_overhead().unwrap();
 
         let aead = space.crypto_seal.as_ref().unwrap();
 
@@ -6755,10 +6789,13 @@ mod tests {
                 testing::decode_pkt(&mut pipe.client, &mut buf, len).unwrap();
             let stream = frames.iter().next().unwrap();
 
-            assert_eq!(stream, &frame::Frame::Stream {
-                stream_id: 8,
-                data: stream::RangeBuf::from(&out, off, false),
-            });
+            assert_eq!(
+                stream,
+                &frame::Frame::Stream {
+                    stream_id: 8,
+                    data: stream::RangeBuf::from(&out, off, false),
+                }
+            );
 
             off = match stream {
                 frame::Frame::Stream { data, .. } => data.max_off(),
@@ -6777,10 +6814,13 @@ mod tests {
                 testing::decode_pkt(&mut pipe.client, &mut buf, len).unwrap();
             let stream = frames.iter().next().unwrap();
 
-            assert_eq!(stream, &frame::Frame::Stream {
-                stream_id: 16,
-                data: stream::RangeBuf::from(&out, off, false),
-            });
+            assert_eq!(
+                stream,
+                &frame::Frame::Stream {
+                    stream_id: 16,
+                    data: stream::RangeBuf::from(&out, off, false),
+                }
+            );
 
             off = match stream {
                 frame::Frame::Stream { data, .. } => data.max_off(),
@@ -6799,10 +6839,13 @@ mod tests {
                 testing::decode_pkt(&mut pipe.client, &mut buf, len).unwrap();
             let stream = frames.iter().next().unwrap();
 
-            assert_eq!(stream, &frame::Frame::Stream {
-                stream_id: 20,
-                data: stream::RangeBuf::from(&out, off, false),
-            });
+            assert_eq!(
+                stream,
+                &frame::Frame::Stream {
+                    stream_id: 20,
+                    data: stream::RangeBuf::from(&out, off, false),
+                }
+            );
 
             off = match stream {
                 frame::Frame::Stream { data, .. } => data.max_off(),
@@ -6835,10 +6878,13 @@ mod tests {
 
             let stream = frames.iter().next().unwrap();
 
-            assert_eq!(stream, &frame::Frame::Stream {
-                stream_id: 4,
-                data: stream::RangeBuf::from(&out, off, false),
-            });
+            assert_eq!(
+                stream,
+                &frame::Frame::Stream {
+                    stream_id: 4,
+                    data: stream::RangeBuf::from(&out, off, false),
+                }
+            );
 
             off = match stream {
                 frame::Frame::Stream { data, .. } => data.max_off(),
@@ -6857,10 +6903,13 @@ mod tests {
                 testing::decode_pkt(&mut pipe.client, &mut buf, len).unwrap();
             let stream = frames.iter().next().unwrap();
 
-            assert_eq!(stream, &frame::Frame::Stream {
-                stream_id: 0,
-                data: stream::RangeBuf::from(&out, off, false),
-            });
+            assert_eq!(
+                stream,
+                &frame::Frame::Stream {
+                    stream_id: 0,
+                    data: stream::RangeBuf::from(&out, off, false),
+                }
+            );
 
             off = match stream {
                 frame::Frame::Stream { data, .. } => data.max_off(),
@@ -7131,6 +7180,7 @@ mod tests {
 
 pub use crate::packet::Header;
 pub use crate::packet::Type;
+pub use crate::padding::PaddingAlgorithm;
 pub use crate::recovery::CongestionControlAlgorithm;
 pub use crate::stream::StreamIter;
 
@@ -7141,9 +7191,9 @@ pub mod h3;
 mod minmax;
 mod octets;
 mod packet;
+mod padding;
 mod rand;
 mod ranges;
 mod recovery;
 mod stream;
 mod tls;
-mod padding;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3020,6 +3020,7 @@ impl Connection {
             return None;
         }
 
+        let now = time::Instant::now();
         let timeout = if self.draining_timer.is_some() {
             // Draining timer takes precedence over all other timers. If it is
             // set it means the connection is closing so there's no point in
@@ -3030,13 +3031,12 @@ impl Connection {
             // detection timers. If they are both unset (i.e. `None`) then the
             // result is `None`, but if at least one of them is set then a
             // `Some(...)` value is returned.
-            let timers = [self.idle_timer, self.recovery.loss_detection_timer()];
+            let timers = [self.idle_timer, self.recovery.loss_detection_timer(), self.padding_algorithm.next_dummy()];
 
             timers.iter().filter_map(|&x| x).min()
         };
 
         if let Some(timeout) = timeout {
-            let now = time::Instant::now();
 
             if timeout <= now {
                 return Some(time::Duration::new(0, 0));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -914,6 +914,9 @@ pub struct Connection {
     /// Whether peer transport parameters were qlogged.
     #[cfg(feature = "qlog")]
     qlogged_peer_params: bool,
+
+    /// The padding algorithm used. See `padding.rs`
+    padding_algorithm: Box<dyn Padding>,
 }
 
 /// Creates a new server-side connection.
@@ -1221,6 +1224,8 @@ impl Connection {
 
             #[cfg(feature = "qlog")]
             qlogged_peer_params: false,
+
+            padding_algorithm: Box::new(NonePadding {}),
         });
 
         if let Some(odcid) = odcid {
@@ -7180,7 +7185,7 @@ mod tests {
 
 pub use crate::packet::Header;
 pub use crate::packet::Type;
-pub use crate::padding::PaddingAlgorithm;
+pub use crate::padding::{NonePadding, Padding, PaddingAlgorithm};
 pub use crate::recovery::CongestionControlAlgorithm;
 pub use crate::stream::StreamIter;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2543,11 +2543,14 @@ impl Connection {
             &self.trace_id,
         );
 
-        if has_data {
-            self.padding_algorithm.update_state(now, PaddingStateEvent::SentRealPacket);
+        let event = if has_data {
+            PaddingStateEvent::SentRealPacket
         } else {
-            self.padding_algorithm.update_state(now, PaddingStateEvent::SentDummyOrTimeoutTriggered);
-        }
+            PaddingStateEvent::SentDummyOrTimeoutTriggered
+        };
+        self.padding_algorithm.update_state(now, event);
+        // this will update the timeout self.padding_algorithm.next_dummy()
+        self.padding_algorithm.sample_next_dummy(now);
 
         qlog_with!(self.qlog_streamer, q, {
             let ev = self.recovery.to_qlog();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2543,6 +2543,12 @@ impl Connection {
             &self.trace_id,
         );
 
+        if has_data {
+            self.padding_algorithm.update_state(PaddingStateEvent::SentRealPacket);
+        } else {
+            self.padding_algorithm.update_state(PaddingStateEvent::SentDummyOrTimeoutTriggered);
+        }
+
         qlog_with!(self.qlog_streamer, q, {
             let ev = self.recovery.to_qlog();
             q.add_event(ev).ok();
@@ -7161,7 +7167,7 @@ mod tests {
 
 pub use crate::packet::Header;
 pub use crate::packet::Type;
-pub use crate::padding::{NonePadding, Padding, PaddingAlgorithm};
+pub use crate::padding::{NonePadding, Padding, PaddingAlgorithm, PaddingStateEvent};
 pub use crate::recovery::CongestionControlAlgorithm;
 pub use crate::stream::StreamIter;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7146,3 +7146,4 @@ mod ranges;
 mod recovery;
 mod stream;
 mod tls;
+mod padding;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2544,9 +2544,9 @@ impl Connection {
         );
 
         if has_data {
-            self.padding_algorithm.update_state(PaddingStateEvent::SentRealPacket);
+            self.padding_algorithm.update_state(now, PaddingStateEvent::SentRealPacket);
         } else {
-            self.padding_algorithm.update_state(PaddingStateEvent::SentDummyOrTimeoutTriggered);
+            self.padding_algorithm.update_state(now, PaddingStateEvent::SentDummyOrTimeoutTriggered);
         }
 
         qlog_with!(self.qlog_streamer, q, {

--- a/src/padding.rs
+++ b/src/padding.rs
@@ -38,8 +38,12 @@ impl FromStr for PaddingAlgorithm {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+/// Enumerate the possible event types that can change the padding algorithm internal state
 pub enum PaddingStateEvent {
+    /// When a packet with application data has been sent
     SentRealPacket,
+
+    /// In all other cases: a dummy has been sent, a timeout has been passed or cancelled
     SentDummyOrTimeoutTriggered,
 }
 

--- a/src/padding.rs
+++ b/src/padding.rs
@@ -6,6 +6,8 @@ use std::str::FromStr;
 use std::time::Duration;
 use std::time::SystemTime;
 
+const PAYLOAD_MIN_LENGTH: usize = 4;
+
 const INFINITY_BIN: f32 = -1f32;
 
 /// Available padding algorithms.
@@ -51,6 +53,9 @@ pub struct NonePadding {}
 
 impl Padding for NonePadding {
     fn pad_individual(&self, size: usize) -> usize {
+        if size < PAYLOAD_MIN_LENGTH {
+            return PAYLOAD_MIN_LENGTH;
+        }
         size
     }
 

--- a/src/padding.rs
+++ b/src/padding.rs
@@ -1,0 +1,160 @@
+use ordered_float::OrderedFloat;
+use rand_distr::{Distribution, Normal, Uniform};
+use std::collections::BTreeMap;
+use std::fmt;
+
+/// AdaptiveHistogramConfig characterizes the initial state of an AdaptiveHistogram.
+/// n_samples, bin_upperbound and n_bins relate to the precision used when building the histogram.
+///  - n_samples dictates how many samples we take to rebuild the distribution;
+///  - bin_upperbound is the "cutoff" after which the tail of the distribution is represented with a single bucket;
+///  - n_bins is the granuarity of the distribution;
+/// Higher values increase computation time and precision.
+/// mu and sigma represent the mean and standard deviation of the target Normal distribution.
+/// These two values are of paramount importance for generating dummies at the right time and should be carefully tuned to match the target traffic.
+#[derive(Debug)]
+struct AdaptiveHistogramConfig {
+    n_samples: u32,
+    bin_upperbound: f32,
+    n_bins: u32,
+    mu: f32,
+    sigma: f32,
+}
+
+impl Default for AdaptiveHistogramConfig {
+    fn default() -> Self {
+        AdaptiveHistogramConfig {
+            n_samples: 100,
+            bin_upperbound: 10f32,
+            n_bins: 10,
+            // Note: this values have been experimentally derived from Tor traffic and have not been adapted to QUIC traffic
+            mu: 0.001564159,
+            sigma: 0.052329599,
+        }
+    }
+}
+/// A histogram that represents an adaptive probability distribution: one can sample/draw a value from this distribution, removing a token from a bin and thus altering the distribution.
+/// Once no token is left, the initial distribution is re-computed.
+/// ```
+/// let mut ah: AdaptiveHistogram = Default::default();
+/// ah.rebuild();
+/// println!("{}", ah);
+/// println!("Value sampled: {}", ah.sample());
+/// ```
+#[derive(Default, Debug)]
+struct AdaptiveHistogram {
+    config: AdaptiveHistogramConfig,
+    histogram: BTreeMap<OrderedFloat<f32>, u32>,
+    tokens_left: u32,
+}
+
+impl AdaptiveHistogram {
+    /// Samples a value from the probability distribution, altering it. If the "distribution is depleted" (all tokens have been drawn), this recomputes a fresh distribution from the configuration.
+    fn sample(&mut self) -> f32 {
+        if self.tokens_left < 1 {
+            self.rebuild()
+        }
+
+        let mut kv = (OrderedFloat(0f32), 1);
+        let mut target_token = Uniform::from(1..self.tokens_left + 1)
+            .sample(&mut rand::thread_rng())
+            as i32;
+        for (&bin, &count) in &self.histogram {
+            target_token -= count as i32;
+            if target_token <= 0 {
+                kv = (bin, count);
+                break;
+            }
+        }
+        self.histogram.insert(kv.0, kv.1 - 1);
+        let selected_bin = kv.0.into();
+        self.tokens_left -= 1;
+        return selected_bin;
+    }
+
+    /// Build a histogram by drawing values from the normal distribution and placing them in buckets. O(N) space, O(N log(N)) time where N is the number of samples
+    fn rebuild(&mut self) {
+        // draw n_samples values from Norm(mu, sigma)
+        let normal = Normal::new(self.config.mu, self.config.sigma).unwrap();
+        let mut values: Vec<f32> = normal
+            .sample_iter(&mut rand::thread_rng())
+            .filter(|&v| v > 0f32)
+            .take(self.config.n_samples as usize)
+            .collect();
+        values.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
+
+        // create n_bins exponentially-increasing bins between 0 and bin_upperbound
+        let n_bins = self.config.n_bins as usize;
+        let mut bins = vec![0f32; n_bins];
+        let mut current_bin = self.config.bin_upperbound;
+        for i in (0..n_bins).rev() {
+            bins[i] = current_bin;
+            current_bin /= 2f32;
+        }
+        bins[0] = 0f32; // smallest bin is always 0
+
+        self.histogram = BTreeMap::new();
+        let mut current_bin_id = 0;
+        let mut i = 0;
+
+        // iterate simultaneously on `values` and `bins`, counting the values the values s.t. bins[i] <= v < bins[i+1]
+        while i < values.len() && current_bin_id < n_bins {
+            let mut j = i;
+            //consume: v while v < bins[i+1], or any v if we reached the last bin
+            while j < values.len()
+                && (current_bin_id == n_bins - 1
+                    || values[j] < bins[current_bin_id + 1])
+            {
+                j += 1;
+            }
+            let count = (j - i) as u32;
+            self.histogram
+                .insert(OrderedFloat(bins[current_bin_id]), count);
+
+            current_bin_id += 1;
+            i = j;
+        }
+        // add empty values for unused bins$
+        while current_bin_id < n_bins {
+            self.histogram.insert(OrderedFloat(bins[current_bin_id]), 0);
+            current_bin_id += 1;
+        }
+        self.tokens_left = self.config.n_samples;
+    }
+}
+
+impl fmt::Display for AdaptiveHistogram {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Ok({
+            for (bin, count) in &self.histogram {
+                writeln!(f, "{}: {}", bin, count).unwrap();
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_adaptive_histogram() {
+        let mut ah: AdaptiveHistogram = Default::default();
+        assert!(ah.tokens_left == 0);
+
+        ah.config.n_samples = 100;
+        ah.rebuild();
+
+        // sample n token
+        for i in 0..ah.config.n_samples {
+            // check that token_left is updated accordingly
+            assert!(ah.config.n_samples - i == ah.tokens_left);
+
+            // check that the token is valid
+            let token = ah.sample();
+            assert!(0f32 <= token && token <= ah.config.bin_upperbound);
+        }
+
+        // next sample() will trigger rebuild() internally
+        let token = ah.sample();
+        assert!(0f32 <= token && token <= ah.config.bin_upperbound);
+        assert!(ah.tokens_left == ah.config.n_samples - 1);
+    }
+}

--- a/src/padding.rs
+++ b/src/padding.rs
@@ -36,7 +36,7 @@ impl FromStr for PaddingAlgorithm {
         }
     }
 }
-
+/// The Padding trait defines how to pad individual packets and generate dummies
 pub trait Padding {
     /// Takes as input a packet size, returns the desired padded size. The caller is responsible for padding the packet to this size.
     fn pad_individual(&self, size: usize) -> usize;
@@ -48,7 +48,7 @@ pub trait Padding {
     fn next_dummy(&mut self) -> Option<(SystemTime, usize)>;
 }
 
-/// A transparent padding algorithm that does nothing
+/// A transparent padding algorithm that only pads individual packets to PAYLOAD_MIN_LENGTH = 4B
 pub struct NonePadding {}
 
 impl Padding for NonePadding {

--- a/src/padding.rs
+++ b/src/padding.rs
@@ -33,13 +33,13 @@ impl Default for WTFPAD {
             WTFPADConfig { padded_size: 1500 },
             // Note: this values have been experimentally derived from Tor traffic and have not been adapted to QUIC traffic
             AdaptiveHistogramConfig {
-                mu: 0.001564159,
-                sigma: 0.052329599,
+                mu: 0.001_564_1,
+                sigma: 0.052_329_6,
                 ..Default::default()
             },
             AdaptiveHistogramConfig {
-                mu: 0.001564159,
-                sigma: 0.052329599,
+                mu: 0.001_564_1,
+                sigma: 0.052_329_6,
                 ..Default::default()
             },
         )
@@ -62,7 +62,7 @@ impl WTFPAD {
 
     /// Simply returns the configured fixed size. The implementation using WTFPAD is responsible for producing a packet of this length.
     fn pad_individual(&self, _size: usize) -> usize {
-        return self.config.padded_size;
+        self.config.padded_size
     }
 
     /// Update_state should be called: when a packet is sent/received (depending to the flow being protected), dummy or not.
@@ -70,9 +70,8 @@ impl WTFPAD {
         if packet_sent && !is_dummy {
             // new transmission after a period of silence, switch to Burst mode
             self.state = State::Burst;
-        }
         // else, if this function was call by a timeout or by a dummy, check if we should "downgrade" the state
-        else if self.state_timeout.is_some()
+        } else if self.state_timeout.is_some()
             && self.state_timeout.unwrap() < SystemTime::now()
         {
             if self.state == State::Burst {
@@ -85,7 +84,7 @@ impl WTFPAD {
 
     /// Returns the time at which the next dummy packet should be sent. Alters self.state_timeout with the returned timeout, if any
     fn next_dummy(&mut self) -> Option<(SystemTime, usize)> {
-        return match self.state {
+        match self.state {
             State::Burst => {
                 let timeout =
                     timeout_to_future_unixtime(self.histogram_burst.sample());
@@ -99,7 +98,7 @@ impl WTFPAD {
                 Some((timeout, self.config.padded_size))
             }
             State::Idle => None,
-        };
+        }
     }
 }
 
@@ -179,7 +178,7 @@ impl AdaptiveHistogram {
             tokens_left: 0,
         };
         ah.rebuild();
-        return ah;
+        ah
     }
 
     /// Samples a value from the probability distribution, altering it. If the "distribution is depleted" (all tokens have been drawn), this recomputes a fresh distribution from the configuration.
@@ -202,7 +201,7 @@ impl AdaptiveHistogram {
         self.histogram.insert(kv.0, kv.1 - 1);
         let selected_bin = kv.0.into();
         self.tokens_left -= 1;
-        return selected_bin;
+        selected_bin
     }
 
     /// Build a histogram by drawing values from the normal distribution and placing them in buckets. O(N) space, O(N log(N)) time where N is the number of samples
@@ -283,16 +282,6 @@ impl AdaptiveHistogram {
             .insert(OrderedFloat(INFINITY_BIN), infinity_bin_count);
 
         self.tokens_left = self.config.n_samples;
-    }
-}
-
-impl fmt::Display for AdaptiveHistogram {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        Ok({
-            for (bin, count) in &self.histogram {
-                writeln!(f, "{}: {}", bin, count).unwrap();
-            }
-        })
     }
 }
 

--- a/src/padding.rs
+++ b/src/padding.rs
@@ -2,12 +2,10 @@ use ordered_float::OrderedFloat;
 use rand_distr::{Distribution, Normal, Uniform};
 use std::collections::BTreeMap;
 use std::fmt;
+use std::time::Duration;
+use std::time::SystemTime;
 
-#[derive(Debug, PartialEq, Eq)]
-enum Direction {
-    Outgoing,
-    Incoming,
-}
+const INFINITY_BIN: f32 = -1f32;
 
 #[derive(Debug, PartialEq, Eq)]
 enum State {
@@ -22,48 +20,61 @@ struct WTFPAD {
     state: State,
     histogram_gap: AdaptiveHistogram,
     histogram_burst: AdaptiveHistogram,
-    state_timeout: SystemTime,
+    state_timeout: Option<SystemTime>,
 }
 #[derive(Debug)]
 struct WTFPADConfig {
     padded_size: usize,
-    histogram_gap: AdaptiveHistogram,
-    histogram_burst: AdaptiveHistogram,
 }
 
-impl Default for WTFPADConfig {
+impl Default for WTFPAD {
     fn default() -> Self {
-        WTFPADConfig {
-            padded_size: 1500,
+        WTFPAD::new(
+            WTFPADConfig { padded_size: 1500 },
             // Note: this values have been experimentally derived from Tor traffic and have not been adapted to QUIC traffic
-            histogram_gap: AdaptiveHistogram::new(AdaptiveHistogramConfig {
+            AdaptiveHistogramConfig {
                 mu: 0.001564159,
                 sigma: 0.052329599,
                 ..Default::default()
-            }),
-            histogram_burst: AdaptiveHistogram::new(AdaptiveHistogramConfig {
+            },
+            AdaptiveHistogramConfig {
                 mu: 0.001564159,
                 sigma: 0.052329599,
                 ..Default::default()
-            }),
-        }
+            },
+        )
     }
 }
 
 impl WTFPAD {
+    pub fn new(
+        config: WTFPADConfig, config_gap: AdaptiveHistogramConfig,
+        config_burst: AdaptiveHistogramConfig,
+    ) -> WTFPAD {
+        WTFPAD {
+            config,
+            state: State::Idle,
+            state_timeout: None,
+            histogram_gap: AdaptiveHistogram::new(config_gap),
+            histogram_burst: AdaptiveHistogram::new(config_burst),
+        }
+    }
+
     /// Simply returns the configured fixed size. The implementation using WTFPAD is responsible for producing a packet of this length.
-    fn pad_individual(&self, size: usize) -> usize {
+    fn pad_individual(&self, _size: usize) -> usize {
         return self.config.padded_size;
     }
 
     /// Update_state should be called: when a packet is sent/received (depending to the flow being protected), dummy or not.
-    fn update_state(&self, packet_sent: bool, is_dummy: bool) {
+    fn update_state(&mut self, packet_sent: bool, is_dummy: bool) {
         if packet_sent && !is_dummy {
             // new transmission after a period of silence, switch to Burst mode
             self.state = State::Burst;
         }
         // else, if this function was call by a timeout or by a dummy, check if we should "downgrade" the state
-        else if self.state_timeout < SystemTime::now() {
+        else if self.state_timeout.is_some()
+            && self.state_timeout.unwrap() < SystemTime::now()
+        {
             if self.state == State::Burst {
                 self.state = State::Gap;
             } else if self.state == State::Gap {
@@ -72,14 +83,31 @@ impl WTFPAD {
         }
     }
 
-    /// Returns the time at which the next dummy packet should be sent.
-    fn next_dummy(&self) -> Option<(f32, usize)> {
+    /// Returns the time at which the next dummy packet should be sent. Alters self.state_timeout with the returned timeout, if any
+    fn next_dummy(&mut self) -> Option<(SystemTime, usize)> {
         return match self.state {
-            State::Burst => Some((self.histogram_burst.sample(), self.config.padded_size)),
-            State::Gap => Some((self.histogram_gap.sample(), self.config.padded_size)),
+            State::Burst => {
+                let timeout =
+                    timeout_to_future_unixtime(self.histogram_burst.sample());
+                self.state_timeout = Some(timeout);
+                Some((timeout, self.config.padded_size))
+            }
+            State::Gap => {
+                let timeout =
+                    timeout_to_future_unixtime(self.histogram_gap.sample());
+                self.state_timeout = Some(timeout);
+                Some((timeout, self.config.padded_size))
+            }
             State::Idle => None,
         };
     }
+}
+
+impl fmt::Display for WTFPAD {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "wtfpad: {:?}", self.state)
+    }
+}
 
 /// AdaptiveHistogramConfig characterizes the initial state of an AdaptiveHistogram.
 /// n_samples, bin_upperbound and n_bins relate to the precision used when building the histogram.
@@ -103,16 +131,14 @@ impl Default for AdaptiveHistogramConfig {
     fn default() -> Self {
         AdaptiveHistogramConfig {
             n_samples: 100,
-            bin_upperbound: 10f32,
+            bin_upperbound: 10.0,
             n_bins: 10,
-            // Note: this values have been experimentally derived from Tor traffic and have not been adapted to QUIC traffic
-            mu: 0.001564159,
-            sigma: 0.052329599,
+            mu: 1.0,
+            sigma: 1.0,
             infinity_bin_config: Default::default(),
         }
     }
 }
-
 #[derive(Debug)]
 struct InfinityBinConfig {
     burst_length: u32,
@@ -132,12 +158,6 @@ impl Default for InfinityBinConfig {
 
 /// A histogram that represents an adaptive probability distribution: one can sample/draw a value from this distribution, removing a token from a bin and thus altering the distribution.
 /// Once no token is left, the initial distribution is re-computed.
-/// ```
-/// let mut ah: AdaptiveHistogram = Default::default();
-/// ah.rebuild();
-/// println!("{}", ah);
-/// println!("Value sampled: {}", ah.sample());
-/// ```
 #[derive(Default, Debug)]
 struct AdaptiveHistogram {
     config: AdaptiveHistogramConfig,
@@ -145,7 +165,23 @@ struct AdaptiveHistogram {
     tokens_left: u32,
 }
 
+/// converts a timeout: f32 into UnixTime corresponding to SystemTime::now() + timeout
+fn timeout_to_future_unixtime(timeout: f32) -> SystemTime {
+    let timeout_ms = (timeout * 1000000.0).ceil() as u64;
+    SystemTime::now() + Duration::from_micros(timeout_ms)
+}
+
 impl AdaptiveHistogram {
+    pub fn new(config: AdaptiveHistogramConfig) -> AdaptiveHistogram {
+        let mut ah = AdaptiveHistogram {
+            config,
+            histogram: BTreeMap::new(),
+            tokens_left: 0,
+        };
+        ah.rebuild();
+        return ah;
+    }
+
     /// Samples a value from the probability distribution, altering it. If the "distribution is depleted" (all tokens have been drawn), this recomputes a fresh distribution from the configuration.
     fn sample(&mut self) -> f32 {
         if self.tokens_left < 1 {
@@ -180,24 +216,24 @@ impl AdaptiveHistogram {
             .collect();
         values.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
 
-        // create n_bins exponentially-increasing bins between 0 and bin_upperbound
+        // create n_bins+1 exponentially-increasing bins between 0 and bin_upperbound
         let n_bins = self.config.n_bins as usize;
-        let mut bins = vec![0f32; n_bins];
+        let mut bins = vec![0f32; n_bins + 1];
         let mut current_bin = self.config.bin_upperbound;
-        for i in (0..n_bins).rev() {
+        for i in (1..=n_bins).rev() {
             bins[i] = current_bin;
             current_bin /= 2f32;
         }
-        bins[0] = 0f32; // smallest bin is always 0
+        bins[0] = 0.0; // smallest bin is always 0
 
         self.histogram = BTreeMap::new();
-        let mut current_bin_id = 0;
+        let mut current_bin_id = 1; // forbid 0 as inter-arrival time
         let mut i = 0;
 
-        // iterate simultaneously on `values` and `bins`, counting the values the values s.t. bins[i] <= v < bins[i+1]
+        // iterate simultaneously on `values` and `bins`, counting the values the values s.t. `bins[i] <= v < bins[i+1]`
         while i < values.len() && current_bin_id < n_bins {
             let mut j = i;
-            //consume: v while v < bins[i+1], or any v if we reached the last bin
+            //consume: `v` while `v < bins[i+1]`, or any `v` if we reached the last bin
             while j < values.len()
                 && (current_bin_id == n_bins - 1
                     || values[j] < bins[current_bin_id + 1])
@@ -212,7 +248,7 @@ impl AdaptiveHistogram {
             i = j;
         }
 
-        // add empty values for unused bins$
+        // add empty values for unused bins
         while current_bin_id < n_bins {
             self.histogram.insert(OrderedFloat(bins[current_bin_id]), 0);
             current_bin_id += 1;
@@ -260,29 +296,97 @@ impl fmt::Display for AdaptiveHistogram {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn test_adaptive_histogram() {
-        let mut ah: AdaptiveHistogram = Default::default();
-        assert!(ah.tokens_left == 0);
+#[test]
+fn test_adaptive_histogram() {
+    let mut ah: AdaptiveHistogram = Default::default();
+    assert!(ah.tokens_left == 0);
 
-        ah.config.n_samples = 100;
-        ah.rebuild();
+    ah.config.n_samples = 100;
+    ah.rebuild();
 
-        // sample n token
-        for i in 0..ah.config.n_samples {
-            // check that token_left is updated accordingly
-            assert!(ah.config.n_samples - i == ah.tokens_left);
+    // sample n token
+    for i in 0..ah.config.n_samples {
+        // check that token_left is updated accordingly
+        assert!(ah.config.n_samples - i == ah.tokens_left);
 
-            // check that the token is valid
-            let token = ah.sample();
-            assert!(0f32 <= token && token <= ah.config.bin_upperbound);
-        }
-
-        // next sample() will trigger rebuild() internally
+        // check that the token is valid
         let token = ah.sample();
         assert!(0f32 <= token && token <= ah.config.bin_upperbound);
-        assert!(ah.tokens_left == ah.config.n_samples - 1);
+    }
+
+    // next sample() will trigger rebuild() internally
+    let token = ah.sample();
+    assert!(0f32 <= token && token <= ah.config.bin_upperbound);
+    assert!(ah.tokens_left == ah.config.n_samples - 1);
+}
+
+#[test]
+fn test_wtpad_states() {
+    let mut w: WTFPAD = Default::default();
+    assert!(w.state == State::Idle);
+
+    // sending a packet in Idle changes to Burst
+    w.state = State::Idle;
+    w.update_state(true, false);
+    assert!(w.state == State::Burst);
+
+    let some_time_ago: SystemTime =
+        SystemTime::now() - Duration::from_millis(100);
+    w.state_timeout = Some(some_time_ago);
+
+    // timeout in Burst changes to Gap
+    w.state = State::Burst;
+    w.update_state(false, false);
+    assert!(w.state == State::Gap);
+
+    // timeout in Gap changes to Idle
+    w.state = State::Gap;
+    w.update_state(false, false);
+    assert!(w.state == State::Idle);
+
+    // TODO: this is what the python implementation does, but it seems odd.
+    // real packet send in Gap changes to Idle
+    w.state = State::Gap;
+    w.update_state(false, true);
+    assert!(w.state == State::Idle);
+}
+
+#[test]
+fn test_wtpad_individual_padding() {
+    let w: WTFPAD = Default::default();
+    assert!(w.pad_individual(1000) == w.config.padded_size);
+}
+
+#[test]
+fn test_wtpad_drawing_samples() {
+    let mut w: WTFPAD = Default::default();
+    w.state = State::Burst;
+    let dummy = w.next_dummy();
+    assert!(dummy.is_some());
+}
+
+#[test]
+fn test_timeout_to_systemtime() {
+    let mut ah: AdaptiveHistogram = Default::default();
+    ah.rebuild();
+
+    let timeout_s = ah.sample();
+    let timeout_unixtime = timeout_to_future_unixtime(timeout_s);
+    let diff = timeout_unixtime.duration_since(SystemTime::now()).unwrap();
+
+    let small_tolerance = 0.001f32; // 1ms
+    assert!((timeout_s - diff.as_secs_f32()).abs() < small_tolerance);
+}
+
+#[test]
+fn test_wtpad() {
+    let mut w: WTFPAD = Default::default();
+    w.state = State::Burst;
+    let dummy = w.next_dummy();
+    assert!(dummy.is_some());
+
+    match w.next_dummy() {
+        Some(i) => println!("{:?}, {}", i.0, i.1),
+        None => println!("No dummy drawn"),
     }
 }


### PR DESCRIPTION
This is an implementation of [wtf-pad](https://github.com/wtfpad/wtfpad) for quiche. It is an algorithm to pad packets and generate dummies that make traffic-analysis harder. 

This PR adds a file `padding.rs` in quiche. On a high-level, the interface is as follows:
```rust
impl Padding {
    /// Takes as input a packet size, returns the desired padded size. The caller is responsible for padding the packet to this size.
    fn pad_individual(&self, _size: usize) -> usize {}

    /// Returns the time at which the next dummy packet should be sent. The caller is responsible for generating a packet at the correct time.
    fn next_dummy(&mut self) -> Option<(SystemTime, usize)> {}

    /// Updates the internal state. Should be called when a timeout is fired or a packet is sent.
    fn update_state(&mut self, packet_sent: bool, is_dummy: bool) {}
}
```

This class lives on its own and has no ties to the rest of the `quiche` code. The `lib.rs` implementation should:
 - instantiate this struct;
 - call `pad_individual` on every outgoing packets, and pad the packets as specified;
 - call `next_dummy` on every outgoing packet, and register the timeout given to send a dummy; on every non-dummy outgoing packet, this timeout should be discarded with no effect.
 - call `update_state` on every outgoing packet.